### PR TITLE
query templates - minimal enum support II

### DIFF
--- a/packages/graphql-playground-react/package.json
+++ b/packages/graphql-playground-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-playground-react",
-  "version": "1.7.28",
+  "version": "1.7.29",
   "main": "./lib/lib.js",
   "typings": "./lib/lib.d.ts",
   "description": "GraphQL IDE for better development workflows (GraphQL Subscriptions, interactive docs & collaboration).",


### PR DESCRIPTION
Bumps package version (missing in #1).