### PR TITLE
dependency update - nowadays prettier version

### DIFF
--- a/packages/graphql-playground-electron/package.json
+++ b/packages/graphql-playground-electron/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/graphcool/graphql-playground",
   "repository": "graphcool/graphql-playground",
   "description": "GraphQL IDE for better development workflows (GraphQL Subscriptions, interactive docs & collaboration)",
-  "version": "1.8.15",
+  "version": "1.8.16",
   "private": true,
   "author": {
     "name": "Graphcool",
@@ -165,7 +165,7 @@
     "postcss-inherit": "git+https://github.com/timsuchanek/postcss-inherit#build3",
     "postcss-loader": "0.9.1",
     "postcss-simple-vars": "3.1.0",
-    "prettier": "2.0.2",
+    "prettier": "^2.6.3",
     "raw-loader": "0.5.1",
     "react-addons-test-utils": "15.6.2",
     "react-test-renderer": "16.4.0",

--- a/packages/graphql-playground-react/package.json
+++ b/packages/graphql-playground-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-playground-react",
-  "version": "1.7.29",
+  "version": "1.7.30",
   "main": "./lib/lib.js",
   "typings": "./lib/lib.d.ts",
   "description": "GraphQL IDE for better development workflows (GraphQL Subscriptions, interactive docs & collaboration).",
@@ -130,7 +130,7 @@
     "lodash.debounce": "^4.0.8",
     "markdown-it": "^8.4.1",
     "marked": "^0.8.2",
-    "prettier": "2.0.2",
+    "prettier": "^2.6.3",
     "prop-types": "^15.7.2",
     "query-string": "5",
     "react": "16.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13346,10 +13346,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.2.tgz#1ba8f3eb92231e769b7fcd7cb73ae1b6b74ade08"
-  integrity sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==
+prettier@^2.6.3:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 pretty-bytes@^1.0.2:
   version "1.0.4"


### PR DESCRIPTION
Updates prettier version. This helps to prevent an error during codegen in Joystream/Hydra that would need to be otherwise prevented by overwriting the dependency version.
